### PR TITLE
RN-06 Update router to react-router-native

### DIFF
--- a/app/components/app.jsx
+++ b/app/components/app.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Text, View } from "react-native";
 import { styles } from "../../styles";
-import { Route,Switch } from 'react-router-dom';
+import { Route,Switch } from 'react-router-native';
 
 const App = () => {
 

--- a/app/components/root.jsx
+++ b/app/components/root.jsx
@@ -1,14 +1,14 @@
 import React from "react";
-import { HashRouter } from 'react-router-dom';
+import { NativeRouter } from 'react-router-native';
 import App from "./app";
 import { Provider } from 'react-redux';
 
 const Root = ({store}) => {
   return(
     <Provider store={store}>
-        <HashRouter>
+        <NativeRouter>
           <App></App>
-        </HashRouter>
+        </NativeRouter>
       </Provider>
   )
 };

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "react-native": "https://github.com/expo/react-native/archive/sdk-39.0.3.tar.gz",
     "react-native-web": "~0.13.12",
     "react-redux": "^7.2.1",
-    "react-router-dom": "^5.2.0",
+    "react-router-native": "^5.2.0",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0"
   },


### PR DESCRIPTION
I had some issues when trying to get the app working on my Android with expo. Seemed to be related to using `react-router-dom`. Updating it to `react-router-native` seemed to do the trick.

Helpful Link: https://reactrouter.com/native/guides/quick-start